### PR TITLE
Juju-using scripts for testing bind-mounted NFS

### DIFF
--- a/nfs-test/clean-containers.sh
+++ b/nfs-test/clean-containers.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+juju ssh $2 lxc delete --force container || true
+juju ssh $3 lxc delete --force container || true

--- a/nfs-test/container.sh
+++ b/nfs-test/container.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while true; do
+    echo `date ; cat /mnt/parent/hostname.txt`
+done;

--- a/nfs-test/migrate-loop.sh
+++ b/nfs-test/migrate-loop.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# args 1 & 2 are juju machine IDs that have lxd set up and a container running on 1.
+
+hostA=host-$1
+hostB=host-$2
+
+set -e
+
+container=container
+
+failures=0
+running_after_dump_failure=0
+successes=0
+
+function do_cr() {
+
+  if [ "$(lxc list $hostA:$container | grep -c "\<$container\>")" -eq "0" ]; then
+    source=$hostB
+    dest=$hostA
+    sourcelogs=/var/lib/lxd/logs/$container
+    destlogs=/var/lib/lxd2/logs/$container
+  else
+    source=$hostA
+    dest=$hostB
+    sourcelogs=/var/lib/lxd2/logs/$container
+    destlogs=/var/lib/lxd/logs/$container
+  fi
+
+  if [ "$(lxc list $source: | grep "\<$container\>" | grep -ci RUNNING)" -eq "0" ]; then
+    lxc start $source:$container
+    sleep 2
+  fi
+
+  bad=0
+  lxc move $source:$container $dest:$container > /tmp/out || bad=1
+  if [ "${bad}" -eq 1 ]; then
+    # dumplog="${sourcelogs}/$(sudo ls -1 ${sourcelogs} | grep dump | tail -n1)"
+    # restorelog="${destlogs}/$(sudo ls -1 ${destlogs} | grep restore | tail -n1)"
+
+    # # figure out which failed
+    # if [ "$(sudo grep -c Error ${dumplog})" -gt "0" ]; then
+    #   if [ "$(lxc list $source: | grep "\<$container\>" | grep -ci RUNNING)" -eq "1" ]; then
+    #     running_after_dump_failure=$(($running_after_dump_failure+1))
+    #   fi
+
+    #   sudo cp $dumplog failurelogs/
+    # else
+    #   sudo cp $restorelog failurelogs/
+    # fi
+
+    failures=$(($failures+1))
+    result="failure"
+  else
+    successes=$(($successes+1))
+    result="success"
+  fi
+
+  lxc stop $source:$container --force &> /dev/null || true
+  lxc stop $dest:$container --force &> /dev/null || true
+}
+
+mkdir -p failurelogs
+
+while true; do
+  echo "=========> starting c/r cycle"
+  do_cr
+  echo "=========> finished c/r: " ${result}
+  echo "successes:" ${successes} "failures:" ${failures} "running after dump failure:" ${running_after_dump_failurea}
+done

--- a/nfs-test/nfshost.sh
+++ b/nfs-test/nfshost.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+sudo apt install -y nfs-kernel-server
+
+grep -q /home/ubuntu /etc/exports ||
+    (
+        cat <<EOF | sudo tee -a /etc/exports
+/home/ubuntu *(rw,sync,no_subtree_check)
+EOF
+    )
+sudo exportfs -a
+
+echo "Written on host" >> /home/ubuntu/afile.txt

--- a/nfs-test/setup.sh
+++ b/nfs-test/setup.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -ex
+
+series=xenial
+
+#juju add-machine -n 3
+
+# maas:
+# juju add-machine $1
+# juju add-machine $2
+# juju add-machine $3
+
+function get_internal_ip
+{
+    juju_host=$1
+    juju ssh $juju_host ip -4 -o addr show | grep -v '\blo\b' | grep -v 'br0' | cut -d ' ' -f 9
+}
+
+function setup_nfs_client
+{
+    juju_host=$1
+    host_name=host-$1
+    host_ip=`get_internal_ip $1`
+    nfs_host=$2
+    nfshost_ip=$3
+
+    juju ssh $juju_host sudo usermod -a -G lxd ubuntu || true
+    juju ssh $juju_host sudo apt install -y zfsutils-linux lxd
+    juju ssh $juju_host sudo lxd init --auto --storage-backend zfs \
+         --storage-create-loop 10 --storage-pool lxd && juju ssh $juju_host sudo dpkg-reconfigure -p medium lxd || true
+    
+    juju ssh $juju_host lxc config set core.trust_password foo
+    juju ssh $juju_host lxc config set core.https_address 0.0.0.0:8443
+
+    juju ssh $nfs_host lxc remote remove $host_name || true
+    juju ssh $nfs_host lxc remote add $host_name $host_ip --accept-certificate --password=foo
+    if [ "$(lxc image list $host_name: | grep -c $series)" -eq "0" ]; then
+        juju ssh $nfs_host lxc image copy ubuntu:$series $host_name: --alias $series --auto-update
+    fi
+
+
+    juju ssh $juju_host -- sudo apt update
+    juju ssh $juju_host -- sudo apt install -y nfs-common
+    juju ssh $juju_host -- sudo mkdir /nfs    
+    juju ssh $juju_host -- sudo mount -t nfs $nfshost_ip:/home/ubuntu /nfs
+
+}
+
+IP_1=`get_internal_ip $1`
+
+juju scp ./nfshost.sh $1:/home/ubuntu/nfshost.sh
+
+juju ssh $1 /home/ubuntu/nfshost.sh
+
+
+setup_nfs_client $2 $1 $IP_1
+setup_nfs_client $3 $1 $IP_1
+
+
+function check_nfs_on_container
+{
+    container=$1
+    nfs_host=$2
+    container_host=$3
+    juju ssh $nfs_host lxc exec $container_host:$container -- cat /nfs/afile.txt
+    juju ssh $nfs_host lxc exec $container_host:$container -- "echo '\nadded on $container' >> /nfs/afile.txt"
+}
+
+juju ssh $1 lxc launch host-$2:$series host-$2:container
+juju ssh $1 lxc config device add container nfs disk source=/nfs path=/nfs
+
+check_nfs_on_container container $1 host-$2

--- a/nfs-test/setup.sh
+++ b/nfs-test/setup.sh
@@ -72,7 +72,7 @@ function check_nfs_on_container
 }
 
 juju ssh $1 lxc launch host-$2:$series host-$2:container
-juju ssh $1 lxc config device add container nfs disk source=/nfs path=/nfs
+juju ssh $1 lxc config device add host-$2:container nfs disk source=/nfs path=/nfs
 #juju ssh $1 lxc config device add container nfs disk source=/home/ubuntu path=/mnt/parent
 
 #juju scp ./container.sh $1:/home/ubuntu/container.sh


### PR DESCRIPTION
Separate scripts based on the others you have in here, only using juju to set up a machine and configure NFS on one host.

TODO: doesn't add-machine for you, need to just do that with one `juju add-machine -n 3' and wait manually for now. It's because waiting is a pain.

After you add machines, find out what numbers they have, say 34 35 36, and `./setup.sh 34 35 36` will set up 34 as an NFS host with ubuntu's homedir exported, and lxd on 34 will have 35 and 36 set up as remotes. It will then mount 34's export on 35 and 36 as /nfs, then launch a container on 35 and bind-mount /nfs into the container.

Signed-off-by: Michael McCracken mike.mccracken@canonical.com
