### PR TITLE
Add sget_fc tracepoint for debugging file system superblock creation

### DIFF
--- a/why-did-mount-fail.bt
+++ b/why-did-mount-fail.bt
@@ -48,6 +48,13 @@ kretprobe:__secure_computing
 	printf("%-6d %-16s mount(?) rejected by seccomp", tid, comm);
 }
 
+kretprobe:sget_fc
+{
+    if (retval != 0) {
+        printf("sget_fc failed in %s (retval=%d)\n", comm, retval);
+    }
+} 
+
 // generic mount entrypoints
 kretprobe:do_mount,
 kretprobe:path_mount,


### PR DESCRIPTION
Hey Tycho, I still use your script for debugging. I recently debugged a `FS_USERNS_MOUNT`-related superblock creation issue with nfs4, and this tracepoint was helpful for tracking down the `EPERM`.